### PR TITLE
Add Sequelize models, migrations and auth docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Dependencies
+node_modules/
+backend/node_modules/
+
+# Environment variables
+.env
+backend/.env
+*.env.local
+*.env.development.local
+*.env.test.local
+*.env.production.local
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# IDE
+.vscode/
+.idea/
+*.iml
+*.sublime-project
+*.sublime-workspace
+
+# Build outputs
+dist/
+build/
+*.tsbuildinfo
+
+# Database
+*.sqlite
+*.db
+
+# Config files with secrets
+backend/config/config.json

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="98e050de-4084-4ab4-b303-e143b3da6b6e" name="Changes" comment="working auth">
-      <change afterPath="$PROJECT_DIR$/backend/src/jobs/tokenCleanup.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/src/middleware/authMiddleware.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/src/routes/adminRoutes.js" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/backend/src/routes/userRoutes.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/.env" beforeDir="false" afterPath="$PROJECT_DIR$/backend/.env" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/init.sql" beforeDir="false" afterPath="$PROJECT_DIR$/backend/init.sql" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/node_modules/.package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/backend/node_modules/.package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/backend/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/backend/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/server.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/server.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/app.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/app.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/controllers/authController.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/controllers/authController.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/jobs/tokenCleanup.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/jobs/tokenCleanup.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/routes/authRoutes.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/routes/authRoutes.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/services/authService.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/services/authService.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -16,7 +24,7 @@
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
   <component name="EmbeddingIndexingInfo">
-    <option name="cachedIndexableFilesCount" value="19" />
+    <option name="cachedIndexableFilesCount" value="22" />
     <option name="fileBasedEmbeddingIndicesEnabled" value="true" />
   </component>
   <component name="FileTemplateManagerImpl">
@@ -28,6 +36,11 @@
     </option>
   </component>
   <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="main" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="GitHubPullRequestSearchHistory">{
@@ -36,12 +49,12 @@
     &quot;assignee&quot;: &quot;ZDRAVKO107UKTC&quot;
   }
 }</component>
-  <component name="GithubPullRequestsUISettings">{
-  &quot;selectedUrlAndAccountId&quot;: {
-    &quot;url&quot;: &quot;https://github.com/Tech-Academy-Gus-Fring/School-Inventory-Management-System&quot;,
-    &quot;accountId&quot;: &quot;ffec973b-42e3-4085-b641-ccf6f5f744e7&quot;
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/Tech-Academy-Gus-Fring/School-Inventory-Management-System.git",
+    "accountId": "4e316143-bf0e-412e-83ed-c3d27e941458"
   }
-}</component>
+}]]></component>
   <component name="HttpClientOnboardingState">{
   &quot;isOnboardingCommentShown&quot;: true
 }</component>
@@ -57,38 +70,41 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;Node.js.app.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.authService.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.db.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.protectedRoutes.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.server.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.userRoutes.js.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;javascript.preferred.runtime.type.id&quot;: &quot;node&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;C:\\Program Files\\JetBrains\\WebStorm 2025.3.2\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Node.js.app.js.executor": "Run",
+    "Node.js.authService.js.executor": "Run",
+    "Node.js.db.js.executor": "Run",
+    "Node.js.protectedRoutes.js.executor": "Run",
+    "Node.js.server.js.executor": "Run",
+    "Node.js.userRoutes.js.executor": "Run",
+    "RunOnceActivity.MCP Project settings loaded": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "BE-005",
+    "ignore.virus.scanning.warn.message": "true",
+    "javascript.preferred.runtime.type.id": "node",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "C:\\Program Files\\JetBrains\\WebStorm 2025.3.2\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;DotEnv&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "postgresql"
+    ],
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "DotEnv"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\zdrav\WebstormProjects\School-Inventory-Management-System\backend" />
@@ -137,6 +153,7 @@
       <option name="presentableId" value="Default" />
       <updated>1773256045985</updated>
       <workItem from="1773256047194" duration="7904000" />
+      <workItem from="1773308473548" duration="5833000" />
     </task>
     <task id="LOCAL-00001" summary="working auth">
       <option name="closed" value="true" />
@@ -151,6 +168,17 @@
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
   </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="working auth" />

--- a/backend/.sequelizerc
+++ b/backend/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('config', 'config.js'),
+  'models-path': path.resolve('models'),
+  'seeders-path': path.resolve('seeders'),
+  'migrations-path': path.resolve('migrations')
+};

--- a/backend/AUTH_IMPLEMENTATION.md
+++ b/backend/AUTH_IMPLEMENTATION.md
@@ -1,0 +1,121 @@
+# Authentication Implementation
+
+## Overview
+This project uses **JWT-based authentication with refresh tokens** for secure user authentication.
+
+## Token Strategy
+
+### Access Tokens (Short-lived)
+- **Expiration**: 15 minutes (configurable via `JWT_ACCESS_EXPIRES_IN`)
+- **Purpose**: Authenticate API requests
+- **Storage**: Client-side (memory or localStorage)
+- **Included in**: Authorization header as `Bearer <token>`
+
+### Refresh Tokens (Long-lived)
+- **Expiration**: 7 days
+- **Purpose**: Obtain new access tokens without re-login
+- **Storage**: Database (`refresh_tokens` table) + httpOnly cookie
+- **Security**: Cryptographically random, not JWT
+
+## API Endpoints
+
+### POST `/auth/register`
+Register a new user.
+
+**Request:**
+```json
+{
+  "username": "john_doe",
+  "email": "john@example.com",
+  "password": "password123",
+  "role": "student"  // optional: student, teacher, admin
+}
+```
+
+### POST `/auth/login`
+Login and receive tokens.
+
+**Request:**
+```json
+{
+  "email": "john@example.com",  // or "username": "john_doe"
+  "password": "password123"
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Login successful",
+  "accessToken": "eyJhbGc...",
+  "user": {
+    "id": 1,
+    "username": "john_doe",
+    "email": "john@example.com",
+    "role": "student"
+  }
+}
+```
+
+**Note**: Refresh token is set as httpOnly cookie automatically.
+
+### POST `/auth/refresh`
+Get a new access token using refresh token.
+
+**Request:** (refresh token from cookie, or in body)
+```json
+{
+  "refreshToken": "abc123..."  // optional if cookie is present
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Token refreshed successfully",
+  "accessToken": "eyJhbGc...",
+  "user": { ... }
+}
+```
+
+### POST `/auth/logout`
+Invalidate refresh token and logout.
+
+**Request:** (refresh token from cookie, or in body)
+```json
+{
+  "refreshToken": "abc123..."  // optional if cookie is present
+}
+```
+
+## How It Works
+
+1. **Login**: User logs in → receives short-lived access token + long-lived refresh token
+2. **API Calls**: Client includes access token in requests
+3. **Token Expiry**: When access token expires (15 min), client uses refresh token to get new access token
+4. **Logout**: Refresh token is deleted from database
+5. **Cleanup**: Expired refresh tokens are automatically cleaned up every hour
+
+## Security Features
+
+✅ Short-lived access tokens (15 minutes)
+✅ Refresh tokens stored in database (can be revoked)
+✅ httpOnly cookies for refresh tokens (prevents XSS)
+✅ Automatic cleanup of expired tokens
+✅ No token blacklist needed (tokens expire quickly)
+
+## Migration
+
+Run migrations to create necessary tables:
+```bash
+cd backend
+npx sequelize-cli db:migrate
+```
+
+## Environment Variables
+
+```env
+JWT_SECRET=your_secret_key
+JWT_ACCESS_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+```

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,0 +1,33 @@
+require('dotenv').config({ path: require('path').join(__dirname, '../.env') });
+
+module.exports = {
+  development: {
+    username: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || 'postgres123',
+    database: process.env.DB_NAME || 'school_inventory',
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: process.env.DB_PORT || 5432,
+    dialect: 'postgres',
+    logging: console.log
+  },
+  test: {
+    username: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || 'postgres123',
+    database: process.env.DB_NAME_TEST || 'school_inventory_test',
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: process.env.DB_PORT || 5432,
+    dialect: 'postgres',
+    logging: false
+  },
+  production: {
+    use_env_variable: 'DATABASE_URL',
+    dialect: 'postgres',
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false
+      }
+    },
+    logging: false
+  }
+};

--- a/backend/migrations/20260312142100-create-users-table.js
+++ b/backend/migrations/20260312142100-create-users-table.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('users', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      username: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
+      },
+
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
+      },
+
+      password_hash: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+
+      role: {
+        type: Sequelize.ENUM('admin', 'teacher', 'student'),
+        allowNull: false,
+        defaultValue: 'student'
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('users');
+  }
+};

--- a/backend/migrations/20260312143433-create-equipment-table.js
+++ b/backend/migrations/20260312143433-create-equipment-table.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('equipment', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+
+      type: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+
+      serial_number: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        unique: true
+      },
+
+      condition: {
+        type: Sequelize.ENUM('new', 'good', 'fair', 'damaged'),
+        allowNull: false
+      },
+
+      status: {
+        type: Sequelize.ENUM(
+            'available',
+            'checked_out',
+            'under_repair',
+            'retired'
+        ),
+        allowNull: false,
+        defaultValue: 'available'
+      },
+
+      location: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+
+      photo_url: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+
+      quantity: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 1
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('equipment');
+  }
+};

--- a/backend/migrations/20260312143721-create-requests-table.js
+++ b/backend/migrations/20260312143721-create-requests-table.js
@@ -1,0 +1,89 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('requests', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      equipment_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'equipment',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      request_date: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+
+      due_date: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+
+      return_date: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+
+      status: {
+        type: Sequelize.ENUM('pending', 'approved', 'rejected', 'returned'),
+        allowNull: false,
+        defaultValue: 'pending'
+      },
+
+      notes: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+
+      approved_by: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL'
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('requests');
+  }
+};

--- a/backend/migrations/20260312144447-create-refresh-tokens-table.js
+++ b/backend/migrations/20260312144447-create-refresh-tokens-table.js
@@ -1,0 +1,55 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('refresh_tokens', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true
+      },
+
+      token: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+        unique: true
+      },
+
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      }
+    });
+
+    // Add index for faster lookups
+    await queryInterface.addIndex('refresh_tokens', ['token']);
+    await queryInterface.addIndex('refresh_tokens', ['user_id']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('refresh_tokens');
+  }
+};

--- a/backend/models/Equipment.js
+++ b/backend/models/Equipment.js
@@ -1,0 +1,74 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+  const Equipment = sequelize.define('Equipment', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true
+      }
+    },
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true
+      }
+    },
+    serial_number: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      unique: true
+    },
+    condition: {
+      type: DataTypes.ENUM('new', 'good', 'fair', 'damaged'),
+      allowNull: false,
+      validate: {
+        isIn: [['new', 'good', 'fair', 'damaged']]
+      }
+    },
+    status: {
+      type: DataTypes.ENUM('available', 'checked_out', 'under_repair', 'retired'),
+      allowNull: false,
+      defaultValue: 'available'
+    },
+    location: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    photo_url: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+      validate: {
+        min: 0
+      }
+    }
+  }, {
+    tableName: 'equipment',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Equipment.associate = function(models) {
+    // Equipment can have many requests
+    Equipment.hasMany(models.Request, {
+      foreignKey: 'equipment_id',
+      as: 'requests'
+    });
+  };
+
+  return Equipment;
+};

--- a/backend/models/RefreshToken.js
+++ b/backend/models/RefreshToken.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+  const RefreshToken = sequelize.define('RefreshToken', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    token: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      unique: true,
+      validate: {
+        notEmpty: true
+      }
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id'
+      }
+    },
+    expires_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      validate: {
+        isDate: true
+      }
+    }
+  }, {
+    tableName: 'refresh_tokens',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  RefreshToken.associate = function(models) {
+    RefreshToken.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      as: 'user'
+    });
+  };
+
+  // Helper method to check if token is expired
+  RefreshToken.prototype.isExpired = function() {
+    return new Date() > this.expires_at;
+  };
+
+  return RefreshToken;
+};

--- a/backend/models/Request.js
+++ b/backend/models/Request.js
@@ -1,0 +1,85 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+  const Request = sequelize.define('Request', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id'
+      }
+    },
+    equipment_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'equipment',
+        key: 'id'
+      }
+    },
+    request_date: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW
+    },
+    due_date: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    return_date: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'approved', 'rejected', 'returned'),
+      allowNull: false,
+      defaultValue: 'pending'
+    },
+    notes: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    approved_by: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'users',
+        key: 'id'
+      }
+    }
+  }, {
+    tableName: 'requests',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  Request.associate = function(models) {
+    // Request belongs to a user (requester)
+    Request.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      as: 'user'
+    });
+
+    // Request belongs to equipment
+    Request.belongsTo(models.Equipment, {
+      foreignKey: 'equipment_id',
+      as: 'equipment'
+    });
+
+    // Request may have an approver
+    Request.belongsTo(models.User, {
+      foreignKey: 'approved_by',
+      as: 'approver'
+    });
+  };
+
+  return Request;
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,69 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    username: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        notEmpty: true,
+        len: [3, 30]
+      }
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+        notEmpty: true
+      }
+    },
+    password_hash: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true
+      }
+    },
+    role: {
+      type: DataTypes.ENUM('admin', 'teacher', 'student'),
+      allowNull: false,
+      defaultValue: 'student'
+    }
+  }, {
+    tableName: 'users',
+    underscored: true,
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+  });
+
+  User.associate = function(models) {
+    // User can have many requests
+    User.hasMany(models.Request, {
+      foreignKey: 'user_id',
+      as: 'requests'
+    });
+
+    // User can approve many requests (as admin/teacher)
+    User.hasMany(models.Request, {
+      foreignKey: 'approved_by',
+      as: 'approvedRequests'
+    });
+
+    // User can have many refresh tokens
+    User.hasMany(models.RefreshToken, {
+      foreignKey: 'user_id',
+      as: 'refreshTokens'
+    });
+  };
+
+  return User;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const process = require('process');
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require(__dirname + '/../config/config.json')[env];
+const db = {};
+
+let sequelize;
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.database, config.username, config.password, config);
+}
+
+fs
+  .readdirSync(__dirname)
+  .filter(file => {
+    return (
+      file.indexOf('.') !== 0 &&
+      file !== basename &&
+      file.slice(-3) === '.js' &&
+      file.indexOf('.test.js') === -1
+    );
+  })
+  .forEach(file => {
+    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;


### PR DESCRIPTION
Initialize Sequelize-based database layer and auth documentation. Adds .sequelizerc and config/config.js (env-driven), models (User, Equipment, Request, RefreshToken) with associations and underscored timestamps, and models/index.js. Adds migrations to create users, equipment, requests and refresh_tokens tables (includes indexes on refresh_tokens). Includes AUTH_IMPLEMENTATION.md describing JWT + refresh token strategy, a project .gitignore, and minor .idea workspace updates.