### PR TITLE
Add admin-only delete endpoint for equipment

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="98e050de-4084-4ab4-b303-e143b3da6b6e" name="Changes" comment="Document API request examples in `API_REQUESTS.md`.">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/API_REQUESTS.md" beforeDir="false" afterPath="$PROJECT_DIR$/backend/API_REQUESTS.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/src/app.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/app.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/controllers/equipmentController.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/controllers/equipmentController.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/src/routes/equipmentRoutes.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/routes/equipmentRoutes.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/src/services/equipmentService.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/services/equipmentService.js" afterDir="false" />
     </list>
@@ -91,7 +90,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "BE-13",
     "ignore.virus.scanning.warn.message": "true",
     "javascript.preferred.runtime.type.id": "node",
     "junie.onboarding.icon.badge.shown": "true",
@@ -174,7 +173,7 @@
       <workItem from="1773308473548" duration="5833000" />
       <workItem from="1773335835721" duration="3539000" />
       <workItem from="1773646039312" duration="118000" />
-      <workItem from="1773646217742" duration="1358000" />
+      <workItem from="1773646217742" duration="2172000" />
     </task>
     <task id="LOCAL-00001" summary="working auth">
       <option name="closed" value="true" />

--- a/backend/API_REQUESTS.md
+++ b/backend/API_REQUESTS.md
@@ -240,6 +240,48 @@ GET /equipment?type=Laptop&condition=good
 
 ---
 
+### 7.1 Delete Equipment (Admin Only)
+**DELETE** `/equipment/:id`
+
+**Example:** `DELETE /equipment/1`
+
+**Headers:**
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Note:** Requires `admin` role. Only equipment with status `retired` can be deleted.
+
+**Response (200):**
+```json
+{
+  "message": "Equipment with ID 1 deleted successfully"
+}
+```
+
+**Response (400) - If not retired:**
+```json
+{
+  "message": "Cannot delete equipment that is not retired"
+}
+```
+
+**Response (403) - If not admin:**
+```json
+{
+  "message": "Access denied. Insufficient permissions."
+}
+```
+
+**Response (404):**
+```json
+{
+  "message": "Equipment with ID 999 not found"
+}
+```
+
+---
+
 ## 🔒 Admin Endpoints
 
 ### 8. Get Admin Dashboard
@@ -332,6 +374,12 @@ curl -X GET http://localhost:5000/equipment/1
 ### Get All Equipment with Search
 ```bash
 curl -X GET "http://localhost:5000/equipment?search=laptop&status=available"
+```
+
+### Delete Equipment (Admin Only)
+```bash
+curl -X DELETE http://localhost:5000/equipment/1 \
+  -H "Authorization: Bearer YOUR_ADMIN_ACCESS_TOKEN_HERE"
 ```
 
 ### Refresh Token

--- a/backend/src/controllers/equipmentController.js
+++ b/backend/src/controllers/equipmentController.js
@@ -55,9 +55,29 @@ const updateStatus = async (req, res) => {
     }
 };
 
+const deleteEquipment = async (req, res) => {
+    try {
+        const {id} = req.params;
+        const result = await equipmentService.deleteEquipment(id);
+
+        if (!result) {
+            return res.status(404).json({message: `Equipment with ID ${id} not found`});
+        }
+
+        return res.status(200).json({message: `Equipment with ID ${id} deleted successfully`});
+    } catch (error) {
+        if (error.message === 'Cannot delete equipment that is not retired') {
+            return res.status(400).json({message: error.message});
+        }
+        console.error("Error deleting equipment:", error);
+        return res.status(500).json({message: "Internal Server Error"});
+    }
+};
+
 module.exports = {
     getEquipmentDetails,
     getEquipment,
     updateStatus,
+    deleteEquipment,
 
 }

--- a/backend/src/routes/equipmentRoutes.js
+++ b/backend/src/routes/equipmentRoutes.js
@@ -7,5 +7,6 @@ const { authenticateToken, authorizeRoles } = require('../middleware/authMiddlew
 router.get('/', equipmentController.getEquipment);
 router.get('/:id', equipmentController.getEquipmentDetails);
 router.put('/:id/status', equipmentController.updateStatus);
+router.delete('/:id', authenticateToken, authorizeRoles("admin"), equipmentController.deleteEquipment);
 
 module.exports = router;

--- a/backend/src/services/equipmentService.js
+++ b/backend/src/services/equipmentService.js
@@ -40,10 +40,24 @@ const updateEquipmentStatus = async (id, status) => {
     return await equipment.update({ status });
 };
 
+const deleteEquipment = async (id) => {
+    const equipment = await Equipment.findByPk(id);
+    if (!equipment) return null;
+
+    // Safe deletion: only allow deletion if equipment is retired
+    if (equipment.status !== 'retired') {
+        throw new Error('Cannot delete equipment that is not retired');
+    }
+
+    await equipment.destroy();
+    return true;
+};
+
 module.exports = { 
     getEquipmentById, 
     getAllEquipment, 
     createEquipment,
     updateEquipment,
-    updateEquipmentStatus
+    updateEquipmentStatus,
+    deleteEquipment
 };


### PR DESCRIPTION
Introduce a safe delete flow for equipment: add equipmentService.deleteEquipment (verifies existence and only allows deletion when status === 'retired'), equipmentController.deleteEquipment (handles 200/400/404/500 responses), and register DELETE /equipment/:id route protected by authenticateToken and authorizeRoles('admin'). Update API_REQUESTS.md with docs and curl example for the delete endpoint. Minor .idea/workspace.xml tweaks to changelist and git-widget placeholder.