### PR TITLE
Add request approval/return flows & admin user API

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,9 +6,14 @@
   <component name="ChangeListManager">
     <list default="true" id="98e050de-4084-4ab4-b303-e143b3da6b6e" name="Changes" comment="Document API request examples in `API_REQUESTS.md`.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/All_API_Requests.md" beforeDir="false" afterPath="$PROJECT_DIR$/backend/All_API_Requests.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/models/Request.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/models/Request.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/postman_collection.json" beforeDir="false" afterPath="$PROJECT_DIR$/backend/postman_collection.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/src/app.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/app.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/src/controllers/equipmentController.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/controllers/equipmentController.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/controllers/requestController.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/controllers/requestController.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/routes/adminRoutes.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/routes/adminRoutes.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/routes/equipmentRoutes.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/routes/equipmentRoutes.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/routes/requestRoutes.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/routes/requestRoutes.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/src/services/requestService.js" beforeDir="false" afterPath="$PROJECT_DIR$/backend/src/services/requestService.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -71,67 +76,54 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;Docker.backend: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;HTTP Request.All in test_equipment.executor&quot;: &quot;Run&quot;,
-    &quot;HTTP Request.test_equipment | Test Get Existing Equipment.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;Node.js.app.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.authService.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.db.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.protectedRoutes.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.server.js.executor&quot;: &quot;Run&quot;,
-    &quot;Node.js.userRoutes.js.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;javascript.preferred.runtime.type.id&quot;: &quot;node&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;com.github.copilot.settings.chat.ChatConfigurable&quot;,
-    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;C:\\Program Files\\JetBrains\\WebStorm 2025.3.2\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Docker.backend: Compose Deployment.executor": "Run",
+    "HTTP Request.All in test_equipment.executor": "Run",
+    "HTTP Request.test_equipment | Test Get Existing Equipment.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Node.js.app.js.executor": "Run",
+    "Node.js.authService.js.executor": "Run",
+    "Node.js.db.js.executor": "Run",
+    "Node.js.protectedRoutes.js.executor": "Run",
+    "Node.js.server.js.executor": "Run",
+    "Node.js.userRoutes.js.executor": "Run",
+    "RunOnceActivity.MCP Project settings loaded": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
+    "git-widget-placeholder": "BE-17/18/19",
+    "ignore.virus.scanning.warn.message": "true",
+    "javascript.preferred.runtime.type.id": "node",
+    "junie.onboarding.icon.badge.shown": "true",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "com.github.copilot.settings.chat.ChatConfigurable",
+    "to.speed.mode.migration.done": "true",
+    "ts.external.directory.path": "C:\\Program Files\\JetBrains\\WebStorm 2025.3.2\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;postgresql&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "postgresql"
     ],
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;DotEnv&quot;
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "DotEnv"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\zdrav\WebstormProjects\School-Inventory-Management-System\backend" />
     </key>
   </component>
-  <component name="RunDashboard">
-    <option name="configurationStatuses">
-      <map>
-        <entry key="HttpClient.HttpRequestRunConfigurationType">
-          <value>
-            <map>
-              <entry key="All in test" value="STOPPED" />
-            </map>
-          </value>
-        </entry>
-      </map>
-    </option>
-  </component>
-  <component name="RunManager" selected="HTTP Request.All in test">
+  <component name="RunManager" selected="Node.js.server.js">
     <configuration name="All in test" type="HttpClient.HttpRequestRunConfigurationType" factoryName="HTTP Request" temporary="true" path="$PROJECT_DIR$/test.http">
       <method v="2" />
     </configuration>
@@ -157,8 +149,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="HTTP Request.All in test" />
         <item itemvalue="Node.js.server.js" />
+        <item itemvalue="HTTP Request.All in test" />
         <item itemvalue="Docker.backend: Compose Deployment" />
         <item itemvalue="Node.js.requestController.js" />
       </list>
@@ -183,7 +175,7 @@
       <workItem from="1773335835721" duration="3539000" />
       <workItem from="1773646039312" duration="118000" />
       <workItem from="1773646217742" duration="1358000" />
-      <workItem from="1773694522894" duration="749000" />
+      <workItem from="1773694522894" duration="3996000" />
     </task>
     <task id="LOCAL-00001" summary="working auth">
       <option name="closed" value="true" />

--- a/backend/All_API_Requests.md
+++ b/backend/All_API_Requests.md
@@ -2,6 +2,27 @@
 
 Base URL: `http://localhost:5000`
 
+## User Roles and Permissions
+
+The system has three user roles with different permissions:
+
+### Student
+- View equipment (public)
+- Submit equipment requests
+- View their own requests
+- Return equipment they borrowed
+
+### Teacher
+- All student permissions
+- Approve/reject equipment requests (can act as department approvers)
+
+### Admin
+- All permissions
+- Create/delete users
+- Create/delete equipment
+- Approve/reject equipment requests
+- Access admin dashboard
+
 ## Authentication Endpoints
 
 - **POST** `/auth/register`
@@ -23,6 +44,14 @@ Base URL: `http://localhost:5000`
 
 ## Admin Endpoints
 
-- **GET** `/admin/dashboard`
+- **GET** `/admin/dashboard` (Admin only)
+- **POST** `/admin/users` (Admin only)
 - **DELETE** `/admin/users/:id` (Admin only)
 
+## Request Endpoints
+
+- **POST** `/request` (Authenticated)
+- **GET** `/request/my` (Authenticated)
+- **PUT** `/request/{id}/approve` (Admin or Teacher)
+- **PUT** `/request/{id}/reject` (Admin or Teacher)
+- **PUT** `/request/{id}/return` (Authenticated)

--- a/backend/migrations/20260316211634-add-return-fields-to-requests.js
+++ b/backend/migrations/20260316211634-add-return-fields-to-requests.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('requests', 'return_condition', {
+      type: Sequelize.STRING,
+      allowNull: true
+    });
+    await queryInterface.addColumn('requests', 'return_notes', {
+      type: Sequelize.TEXT,
+      allowNull: true
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('requests', 'return_condition');
+    await queryInterface.removeColumn('requests', 'return_notes');
+  }
+};

--- a/backend/models/Request.js
+++ b/backend/models/Request.js
@@ -52,6 +52,14 @@ module.exports = (sequelize, DataTypes) => {
         model: 'users',
         key: 'id'
       }
+    },
+    return_condition: {
+      type: DataTypes.ENUM('new', 'good', 'fair', 'damaged'),
+      allowNull: true
+    },
+    return_notes: {
+      type: DataTypes.TEXT,
+      allowNull: true
     }
   }, {
     tableName: 'requests',

--- a/backend/postman_collection.json
+++ b/backend/postman_collection.json
@@ -48,6 +48,48 @@
           }
         },
         {
+          "name": "Register Teacher",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"teacher_user\",\n  \"email\": \"teacher@example.com\",\n  \"password\": \"password123\",\n  \"role\": \"teacher\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/register",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "register"]
+            }
+          }
+        },
+        {
+          "name": "Register Admin",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"admin_user\",\n  \"email\": \"admin@example.com\",\n  \"password\": \"password123\",\n  \"role\": \"admin\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/register",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "register"]
+            }
+          }
+        },
+        {
           "name": "Login with Email",
           "event": [
             {
@@ -103,6 +145,70 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"username\": \"john_doe\",\n  \"password\": \"password123\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          }
+        },
+        {
+          "name": "Login as Teacher",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "pm.collectionVariables.set(\"accessToken\", jsonData.accessToken);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"teacher@example.com\",\n  \"password\": \"password123\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "login"]
+            }
+          }
+        },
+        {
+          "name": "Login as Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "pm.collectionVariables.set(\"accessToken\", jsonData.accessToken);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@example.com\",\n  \"password\": \"password123\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/auth/login",
@@ -381,6 +487,31 @@
           }
         },
         {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"admin_user\",\n  \"email\": \"admin@example.com\",\n  \"password\": \"password123\",\n  \"role\": \"admin\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/users",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users"]
+            }
+          }
+        },
+        {
           "name": "Delete User by ID",
           "request": {
             "method": "DELETE",
@@ -394,6 +525,120 @@
               "raw": "{{baseUrl}}/admin/users/5",
               "host": ["{{baseUrl}}"],
               "path": ["admin", "users", "5"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Requests",
+      "item": [
+        {
+          "name": "Approve Request",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/request/:id/approve",
+              "host": ["{{baseUrl}}"],
+              "path": ["request", ":id", "approve"]
+            }
+          }
+        },
+        {
+          "name": "Reject Request",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"Equipment is under maintenance\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/request/:id/reject",
+              "host": ["{{baseUrl}}"],
+              "path": ["request", ":id", "reject"]
+            }
+          }
+        },
+        {
+          "name": "Return Request",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"condition\": \"good\",\n  \"notes\": \"Returned in good condition\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/request/:id/return",
+              "host": ["{{baseUrl}}"],
+              "path": ["request", ":id", "return"]
+            }
+          }
+        },
+        {
+          "name": "Submit Request",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"equipment_id\": 1,\n  \"request_date\": \"2026-03-16\",\n  \"due_date\": \"2026-03-20\",\n  \"notes\": \"Need for class project\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/request",
+              "host": ["{{baseUrl}}"],
+              "path": ["request"]
+            }
+          }
+        },
+        {
+          "name": "Get My Requests",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/request/my",
+              "host": ["{{baseUrl}}"],
+              "path": ["request", "my"]
             }
           }
         }

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,63 @@
+const { User } = require('../../models');
+const bcrypt = require('bcrypt');
+
+const createUser = async (req, res) => {
+    try {
+        const { username, email, password, role } = req.body;
+
+        // Validate required fields
+        if (!username || !email || !password || !role) {
+            return res.status(400).json({
+                message: "Missing required fields: username, email, password, role"
+            });
+        }
+
+        // Validate role
+        const validRoles = ['student', 'teacher', 'admin'];
+        if (!validRoles.includes(role)) {
+            return res.status(400).json({
+                message: `Invalid role. Allowed values: ${validRoles.join(', ')}`
+            });
+        }
+
+        // Check if user already exists
+        const existingUser = await User.findOne({
+            where: {
+                [require('sequelize').Op.or]: [
+                    { email },
+                    { username }
+                ]
+            }
+        });
+
+        if (existingUser) {
+            return res.status(409).json({
+                message: "User with this email or username already exists"
+            });
+        }
+
+        // Hash password
+        const hashedPassword = await bcrypt.hash(password, 10);
+
+        // Create user
+        const newUser = await User.create({
+            username,
+            email,
+            password: hashedPassword,
+            role
+        });
+
+        // Return user without password
+        const { password: _, ...userWithoutPassword } = newUser.toJSON();
+
+        return res.status(201).json({
+            message: "User created successfully",
+            user: userWithoutPassword
+        });
+    } catch (error) {
+        console.error('Error creating user:', error);
+        return res.status(500).json({ message: 'Internal Server Error' });
+    }
+};
+
+module.exports = { createUser };

--- a/backend/src/controllers/requestController.js
+++ b/backend/src/controllers/requestController.js
@@ -29,6 +29,9 @@ const submitRequest = async (req, res) => {
 
         res.status(201).json(newRequest);
     } catch (error) {
+        if (error.statusCode) {
+            return res.status(error.statusCode).json({ message: error.message });
+        }
         console.error("Request Error:", error);
         res.status(500).json({ message: "Internal Server Error" });
     }
@@ -43,4 +46,75 @@ const getUserRequests = async (req, res) => {
     }
 };
 
-module.exports = { submitRequest, getUserRequests };
+const approveRequest = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const approverId = req.user.userId; // Assuming req.user has userId
+
+        const request = await requestService.approveRequest(id, approverId);
+
+        return res.status(200).json({
+            message: 'Request approved successfully',
+            request
+        });
+    } catch (error) {
+        if (error.message === 'Request not found') {
+            return res.status(404).json({ message: error.message });
+        }
+        if (error.message === 'Only pending requests can be approved' || error.message === 'Equipment is no longer available') {
+            return res.status(400).json({ message: error.message });
+        }
+        console.error('Error approving request:', error);
+        return res.status(500).json({ message: 'Internal Server Error' });
+    }
+};
+
+const rejectRequest = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { reason } = req.body; // Optional rejection reason
+        const rejectorId = req.user.userId;
+
+        const request = await requestService.rejectRequest(id, rejectorId, reason);
+
+        return res.status(200).json({
+            message: 'Request rejected successfully',
+            request
+        });
+    } catch (error) {
+        if (error.message === 'Request not found') {
+            return res.status(404).json({ message: error.message });
+        }
+        if (error.message === 'Only pending requests can be rejected') {
+            return res.status(400).json({ message: error.message });
+        }
+        console.error('Error rejecting request:', error);
+        return res.status(500).json({ message: 'Internal Server Error' });
+    }
+};
+
+const returnRequest = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { condition, notes } = req.body; // Return condition and notes
+        const userId = req.user.userId;
+
+        const request = await requestService.returnRequest(id, userId, condition, notes);
+
+        return res.status(200).json({
+            message: 'Request returned successfully',
+            request
+        });
+    } catch (error) {
+        if (error.message === 'Request not found') {
+            return res.status(404).json({ message: error.message });
+        }
+        if (error.message === 'Only approved requests can be returned' || error.message === 'You can only return your own requests') {
+            return res.status(400).json({ message: error.message });
+        }
+        console.error('Error returning request:', error);
+        return res.status(500).json({ message: 'Internal Server Error' });
+    }
+};
+
+module.exports = { submitRequest, getUserRequests, approveRequest, rejectRequest, returnRequest };

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -3,6 +3,7 @@ const {
     authenticateToken,
     authorizeRoles,
 } = require("../middleware/authMiddleware");
+const adminController = require("../controllers/adminController");
 
 const router = express.Router();
 
@@ -16,6 +17,13 @@ router.get(
             user: req.user,
         });
     }
+);
+
+router.post(
+    "/users",
+    authenticateToken,
+    authorizeRoles("admin"),
+    adminController.createUser
 );
 
 router.delete(

--- a/backend/src/routes/equipmentRoutes.js
+++ b/backend/src/routes/equipmentRoutes.js
@@ -6,9 +6,6 @@ const { authenticateToken, authorizeRoles } = require('../middleware/authMiddlew
 // Публични маршрути
 router.post('/', authenticateToken, authorizeRoles("admin"), equipmentController.createEquipment);
 router.get('/', equipmentController.getEquipment);
-router.get('/my-requests', authenticateToken, equipmentController.getMyRequests);
-router.get('/manager/requests', authenticateToken, authorizeRoles("admin"), equipmentController.getAdminRequests);
-router.post('/requests', authenticateToken, equipmentController.submitRequest);
 
 // ДИНАМИЧНИ
 router.get('/:id', equipmentController.getEquipmentDetails);

--- a/backend/src/routes/requestRoutes.js
+++ b/backend/src/routes/requestRoutes.js
@@ -1,12 +1,21 @@
 const express = require('express');
 const router = express.Router();
 const requestController = require('../controllers/requestController');
-const { authenticateToken } = require('../middleware/authMiddleware');
+const { authenticateToken, authorizeRoles } = require('../middleware/authMiddleware');
 
 // Requirement: POST /request (Authenticated)
 router.post('/', authenticateToken, requestController.submitRequest);
 
 // BE-015: GET current user requests
 router.get('/my', authenticateToken, requestController.getUserRequests);
+
+// BE-017: PUT /request/{id}/approve (Admin or Teacher)
+router.put('/:id/approve', authenticateToken, authorizeRoles('admin', 'teacher'), requestController.approveRequest);
+
+// BE-018: PUT /request/{id}/reject (Admin or Teacher)
+router.put('/:id/reject', authenticateToken, authorizeRoles('admin', 'teacher'), requestController.rejectRequest);
+
+// BE-019: PUT /request/{id}/return (Authenticated)
+router.put('/:id/return', authenticateToken, requestController.returnRequest);
 
 module.exports = router;

--- a/backend/src/services/requestService.js
+++ b/backend/src/services/requestService.js
@@ -30,7 +30,96 @@ const getMyRequests = async (userId) => {
     });
 };
 
+const approveRequest = async (requestId, approverId) => {
+    const request = await Request.findByPk(requestId, {
+        include: [{ model: Equipment, as: 'equipment' }]
+    });
+
+    if (!request) {
+        throw new Error('Request not found');
+    }
+
+    if (request.status !== 'pending') {
+        throw new Error('Only pending requests can be approved');
+    }
+
+    // Recheck equipment availability
+    if (request.equipment.status !== 'available') {
+        throw new Error('Equipment is no longer available');
+    }
+
+    // Update request status to approved
+    request.status = 'approved';
+    request.approved_by = approverId;
+    await request.save();
+
+    // Update equipment status to checked_out
+    request.equipment.status = 'checked_out';
+    await request.equipment.save();
+
+    return request;
+};
+
+const rejectRequest = async (requestId, rejectorId, reason) => {
+    const request = await Request.findByPk(requestId);
+
+    if (!request) {
+        throw new Error('Request not found');
+    }
+
+    if (request.status !== 'pending') {
+        throw new Error('Only pending requests can be rejected');
+    }
+
+    // Update request status to rejected
+    request.status = 'rejected';
+    if (reason) {
+        request.notes = reason; // Store rejection reason in notes
+    }
+    await request.save();
+
+    return request;
+};
+
+const returnRequest = async (requestId, userId, condition, notes) => {
+    const request = await Request.findByPk(requestId, {
+        include: [{ model: Equipment, as: 'equipment' }]
+    });
+
+    if (!request) {
+        throw new Error('Request not found');
+    }
+
+    if (request.user_id !== userId) {
+        throw new Error('You can only return your own requests');
+    }
+
+    if (request.status !== 'approved') {
+        throw new Error('Only approved requests can be returned');
+    }
+
+    // Update request status to returned
+    request.status = 'returned';
+    request.return_date = new Date();
+    if (condition) {
+        request.return_condition = condition;
+    }
+    if (notes) {
+        request.return_notes = notes;
+    }
+    await request.save();
+
+    // Update equipment status to available
+    request.equipment.status = 'available';
+    await request.equipment.save();
+
+    return request;
+};
+
 module.exports = {
     createBorrowRequest,
-    getMyRequests
+    getMyRequests,
+    approveRequest,
+    rejectRequest,
+    returnRequest
 };


### PR DESCRIPTION
Add end-to-end support for approving, rejecting, and returning equipment requests and an admin user creation endpoint. Changes include:

- DB: new migration adds requests.return_condition and requests.return_notes.
- Model: Request model extended with return_condition (enum) and return_notes.
- Service: requestService adds approveRequest, rejectRequest, returnRequest (update request statuses, equipment availability, store return metadata, and validation checks).
- Controller/Routes: requestController gains approve/reject/return handlers; requestRoutes adds protected endpoints (approve/reject for admin/teacher, return for authenticated users). adminController.createUser added and wired into adminRoutes (admin-only).
- API surface: All_API_Requests.md and postman_collection.json updated with role info and new requests/endpoints (register/login as teacher/admin, admin user creation, request approve/reject/return, submit/get-my requests).
- Minor: cleaned up equipmentRoutes and updated IDE workspace metadata.

These changes implement business flows for request lifecycle (approve → checked_out, return → available) and enable admin user management.